### PR TITLE
Kimchoyoung-Strategy Patterns

### DIFF
--- a/jOOQ-checker/.classpath
+++ b/jOOQ-checker/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/jOOQ-checker/.project
+++ b/jOOQ-checker/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>jOOQ-checker</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/jOOQ-checker/.settings/org.eclipse.core.resources.prefs
+++ b/jOOQ-checker/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding/<project>=UTF-8

--- a/jOOQ-checker/.settings/org.eclipse.jdt.core.prefs
+++ b/jOOQ-checker/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/jOOQ-checker/src/main/java/org/jooq/checker/AbstractChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/AbstractChecker.java
@@ -50,7 +50,12 @@ import org.checkerframework.framework.source.SourceChecker;
  * @author Lukas Eder
  */
 abstract class AbstractChecker extends SourceChecker {
-
+	MethodInvocation methodinvocation;
+	
+	void setMethodInvocation(MethodInvocation methodinvocation) {
+		this.methodinvocation=methodinvocation;
+	}
+	
     void error(Object node, String message) {
         getChecker().report(Result.failure(message, node), node);
     }
@@ -58,7 +63,7 @@ abstract class AbstractChecker extends SourceChecker {
     void warn(Object node, String message) {
         getChecker().report(Result.warning(message, node), node);
     }
-
+    
     void print(Printer printer) {
         try (PrintWriter writer = new PrintWriter(new FileWriter("error.txt"))){
             writer.println("This is probably a bug in jOOQ-checker.");

--- a/jOOQ-checker/src/main/java/org/jooq/checker/MethodInvocation.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/MethodInvocation.java
@@ -1,0 +1,7 @@
+package org.jooq.checker;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+public interface MethodInvocation {
+	String checker(MethodInvocationTree node, Void p, CompilationUnitTree root);
+}

--- a/jOOQ-checker/src/main/java/org/jooq/checker/PlainAnnoationChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/PlainAnnoationChecker.java
@@ -1,0 +1,42 @@
+package org.jooq.checker;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import static com.sun.source.util.TreePath.getPath;
+import static org.checkerframework.javacutil.TreeUtils.elementFromDeclaration;
+import static org.checkerframework.javacutil.TreeUtils.elementFromUse;
+import static org.checkerframework.javacutil.TreeUtils.enclosingMethod;
+import org.jooq.Allow;
+import org.jooq.PlainSQL;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+public class PlainAnnoationChecker implements MethodInvocation{
+
+	@Override
+	public String checker(MethodInvocationTree node, Void p, CompilationUnitTree root) {
+        ExecutableElement elementFromUse = elementFromUse(node);
+        PlainSQL plainSQL = elementFromUse.getAnnotation(PlainSQL.class);
+
+        // In the absence of a @PlainSQL annotation,
+        // all jOOQ API method calls will type check.
+        if (plainSQL != null) {
+            Element enclosing = elementFromDeclaration(enclosingMethod(getPath(root, node)));
+            boolean allowed = false;
+
+            moveUpEnclosingLoop:
+            while (enclosing != null) {
+                if (enclosing.getAnnotation(Allow.PlainSQL.class) != null) {
+                    allowed = true;
+                    break moveUpEnclosingLoop;
+                }
+                enclosing = enclosing.getEnclosingElement();
+            }
+            if (!allowed)
+                return "Plain SQL usage not allowed at current scope. Use @Allow.PlainSQL.";
+        }
+		return null;	
+	}
+
+}

--- a/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
@@ -37,17 +37,7 @@
  */
 package org.jooq.checker;
 
-import static com.sun.source.util.TreePath.getPath;
-import static org.checkerframework.javacutil.TreeUtils.elementFromDeclaration;
-import static org.checkerframework.javacutil.TreeUtils.elementFromUse;
-import static org.checkerframework.javacutil.TreeUtils.enclosingMethod;
-
 import java.io.PrintWriter;
-
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-
-import org.jooq.Allow;
 import org.jooq.PlainSQL;
 
 import org.checkerframework.framework.source.SourceVisitor;
@@ -62,47 +52,27 @@ import com.sun.source.tree.MethodInvocationTree;
  */
 public class PlainSQLChecker extends AbstractChecker {
 
-    @Override
-    protected SourceVisitor<Void, Void> createSourceVisitor() {
-        return new SourceVisitor<Void, Void>(getChecker()) {
+	@Override
+	protected SourceVisitor<Void, Void> createSourceVisitor() {
+		return new SourceVisitor<Void, Void>(getChecker()) {
 
-            @Override
-            public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-                try {
-                    ExecutableElement elementFromUse = elementFromUse(node);
-                    PlainSQL plainSQL = elementFromUse.getAnnotation(PlainSQL.class);
-
-                    // In the absence of a @PlainSQL annotation,
-                    // all jOOQ API method calls will type check.
-                    if (plainSQL != null) {
-                        Element enclosing = elementFromDeclaration(enclosingMethod(getPath(root, node)));
-                        boolean allowed = false;
-
-                        moveUpEnclosingLoop:
-                        while (enclosing != null) {
-                            if (enclosing.getAnnotation(Allow.PlainSQL.class) != null) {
-                                allowed = true;
-                                break moveUpEnclosingLoop;
-                            }
-
-                            enclosing = enclosing.getEnclosingElement();
-                        }
-
-                        if (!allowed)
-                            error(node, "Plain SQL usage not allowed at current scope. Use @Allow.PlainSQL.");
-                    }
-                }
-                catch (final Exception e) {
-                    print(new Printer() {
-                        @Override
-                        public void print(PrintWriter t) {
-                            e.printStackTrace(t);
-                        }
-                    });
-                }
-
-                return super.visitMethodInvocation(node, p);
-            }
-        };
-    }
+			@Override
+			public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+				try {
+					String str=methodinvocation.checker(node, p, root); // 수
+					if (str!=null)
+						error(node, str);
+				}
+				catch (final Exception e) {
+					print(new Printer() {
+						@Override
+						public void print(PrintWriter t) {
+							e.printStackTrace(t);
+						}
+					});
+				}
+				return super.visitMethodInvocation(node, p);
+			}
+		};
+	}
 }

--- a/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
@@ -37,19 +37,7 @@
  */
 package org.jooq.checker;
 
-import static com.sun.source.util.TreePath.getPath;
-import static java.util.Arrays.asList;
-import static org.checkerframework.javacutil.TreeUtils.elementFromDeclaration;
-import static org.checkerframework.javacutil.TreeUtils.elementFromUse;
-import static org.checkerframework.javacutil.TreeUtils.enclosingMethod;
-
 import java.io.PrintWriter;
-import java.util.EnumSet;
-
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-
-import org.jooq.Allow;
 import org.jooq.Require;
 import org.jooq.SQLDialect;
 import org.jooq.Support;
@@ -66,92 +54,28 @@ import com.sun.source.tree.MethodInvocationTree;
  */
 public class SQLDialectChecker extends AbstractChecker {
 
-    @Override
-    protected SourceVisitor<Void, Void> createSourceVisitor() {
-        return new SourceVisitor<Void, Void>(getChecker()) {
+	@Override
+	protected SourceVisitor<Void, Void> createSourceVisitor() {
+		return new SourceVisitor<Void, Void>(getChecker()) {
 
-            @Override
-            public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-                try {
-                    ExecutableElement elementFromUse = elementFromUse(node);
-                    Support support = elementFromUse.getAnnotation(Support.class);
+			@Override
+			public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+				try {
 
-                    // In the absence of a @Support annotation, or if no SQLDialect is supplied,
-                    // all jOOQ API method calls will type check.
-                    if (support != null && support.value().length > 0) {
-                        Element enclosing = elementFromDeclaration(enclosingMethod(getPath(root, node)));
-
-                        EnumSet<SQLDialect> supported = EnumSet.copyOf(asList(support.value()));
-                        EnumSet<SQLDialect> allowed = EnumSet.noneOf(SQLDialect.class);
-                        EnumSet<SQLDialect> required = EnumSet.noneOf(SQLDialect.class);
-
-                        boolean evaluateRequire = true;
-                        while (enclosing != null) {
-                            Allow allow = enclosing.getAnnotation(Allow.class);
-
-                            if (allow != null)
-                                allowed.addAll(asList(allow.value()));
-
-                            if (evaluateRequire) {
-                                Require require = enclosing.getAnnotation(Require.class);
-
-                                if (require != null) {
-                                    evaluateRequire = false;
-
-                                    required.clear();
-                                    required.addAll(asList(require.value()));
-                                }
-                            }
-
-                            enclosing = enclosing.getEnclosingElement();
-                        }
-
-                        if (allowed.isEmpty())
-                            error(node, "No jOOQ API usage is allowed at current scope. Use @Allow.");
-
-                        if (required.isEmpty())
-                            error(node, "No jOOQ API usage is allowed at current scope due to conflicting @Require specification.");
-
-                        boolean allowedFail = true;
-                        allowedLoop:
-                        for (SQLDialect a : allowed) {
-                            for (SQLDialect s : supported) {
-                                if (a.supports(s)) {
-                                    allowedFail = false;
-                                    break allowedLoop;
-                                }
-                            }
-                        }
-
-                        if (allowedFail)
-                            error(node, "The allowed dialects in scope " + allowed + " do not include any of the supported dialects: " + supported);
-
-                        boolean requiredFail = false;
-                        requiredLoop:
-                        for (SQLDialect r : required) {
-                            for (SQLDialect s : supported)
-                                if (r.supports(s))
-                                    continue requiredLoop;
-
-                            requiredFail = true;
-                            break requiredLoop;
-                        }
-
-                        if (requiredFail)
-                            error(node, "Not all of the required dialects " + required + " from the current scope are supported " + supported);
-                    }
-                }
-                catch (final Exception e) {
-                    print(new Printer() {
-                        @Override
-                        public void print(PrintWriter t) {
-                            e.printStackTrace(t);
-                        }
-                    });
-                }
-
-                return super.visitMethodInvocation(node, p);
-            }
-        };
-    }
+					String error_msg=methodinvocation.checker(node,p,root);
+					if(error_msg!=null);
+					error(node, error_msg);
+				}
+				catch (final Exception e) {
+					print(new Printer() {
+						@Override
+						public void print(PrintWriter t) {
+							e.printStackTrace(t);
+						}
+					});
+				}
+				return super.visitMethodInvocation(node, p);
+			}
+		};
+	}
 }

--- a/jOOQ-checker/src/main/java/org/jooq/checker/SupportAnnotationCheck.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/SupportAnnotationCheck.java
@@ -1,0 +1,96 @@
+package org.jooq.checker;
+
+import static com.sun.source.util.TreePath.getPath;
+import static java.util.Arrays.asList;
+import static org.checkerframework.javacutil.TreeUtils.elementFromDeclaration;
+import static org.checkerframework.javacutil.TreeUtils.elementFromUse;
+import static org.checkerframework.javacutil.TreeUtils.enclosingMethod;
+
+import java.util.EnumSet;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+
+import org.jooq.Allow;
+import org.jooq.Require;
+import org.jooq.SQLDialect;
+import org.jooq.Support;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+public class SupportAnnotationCheck implements MethodInvocation {
+
+	@Override
+	public String checker(MethodInvocationTree node, Void p, CompilationUnitTree root) {
+
+		ExecutableElement elementFromUse = elementFromUse(node);
+		Support support = elementFromUse.getAnnotation(Support.class);
+
+		// In the absence of a @Support annotation, or if no SQLDialect is supplied,
+		// all jOOQ API method calls will type check.
+		if (support != null && support.value().length > 0) {
+			Element enclosing = elementFromDeclaration(enclosingMethod(getPath(root, node)));
+
+			EnumSet<SQLDialect> supported = EnumSet.copyOf(asList(support.value()));
+			EnumSet<SQLDialect> allowed = EnumSet.noneOf(SQLDialect.class);
+			EnumSet<SQLDialect> required = EnumSet.noneOf(SQLDialect.class);
+
+			boolean evaluateRequire = true;
+			while (enclosing != null) {
+				Allow allow = enclosing.getAnnotation(Allow.class);
+
+				if (allow != null)
+					allowed.addAll(asList(allow.value()));
+
+				if (evaluateRequire) {
+					Require require = enclosing.getAnnotation(Require.class);
+
+					if (require != null) {
+						evaluateRequire = false;
+
+						required.clear();
+						required.addAll(asList(require.value()));
+					}
+				}
+
+				enclosing = enclosing.getEnclosingElement();
+			}
+
+			if (allowed.isEmpty())
+				return "No jOOQ API usage is allowed at current scope. Use @Allow.";
+			if (required.isEmpty())
+				return "No jOOQ API usage is allowed at current scope due to conflicting @Require specification.";
+			boolean allowedFail = true;
+			allowedLoop:
+				for (SQLDialect a : allowed) {
+					for (SQLDialect s : supported) {
+						if (a.supports(s)) {
+							allowedFail = false;
+							break allowedLoop;
+						}
+					}
+				}
+
+			if (allowedFail)
+				return "The allowed dialects in scope " + allowed + " do not include any of the supported dialects: " + supported;
+
+			boolean requiredFail = false;
+			requiredLoop:
+				for (SQLDialect r : required) {
+					for (SQLDialect s : supported)
+						if (r.supports(s))
+							continue requiredLoop;
+
+					requiredFail = true;
+					break requiredLoop;
+				}
+
+			if (requiredFail)
+				return "Not all of the required dialects " + required + " from the current scope are supported " + supported;
+
+		}
+		return null;
+
+	}
+}

--- a/jOOQ-checker/src/main/java/org/jooq/checker/stratergy pattern
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/stratergy pattern
@@ -1,0 +1,12 @@
+
+
+the classes in this package were not applied to strategy pattern
+this classes checks about annotation. if there are no annotations, it will return error msg.
+
+but the error msg and the ways of checking errors can be changed later.
+it violates OCP.
+
+So, I made interface to check the kinds of annotation error and divided class then
+made them inherit relations. this pattern is called strategy patterns.
+
+


### PR DESCRIPTION
the classes in this package were not applied to strategy pattern
this classes checks about annotation. if there are no annotations, it will return error msg.

but the error msg and the ways of checking errors can be changed later.
it violates OCP.

So, I made interface to check the kinds of annotation error and divided class then
made them inherit relations. this pattern is called strategy patterns.